### PR TITLE
Feature: get access control task

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,9 @@ require("hardhat-contract-sizer");
 require("hardhat-ignore-warnings");
 require("@nomicfoundation/hardhat-toolbox");
 
+const hhtasks = require("./hhtasks");
+hhtasks.addTasks();
+
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -21,19 +21,19 @@ module.exports = {
   },
   networks: {
     sepolia: {
-      url: process.env.RPC_URL_SEPOLIA || process.env.RPC_URL,
+      url: process.env.RPC_URL_SEPOLIA || process.env.RPC_URL || "",
       chainId: 11155111,
     },
     mainnet: {
-      url: process.env.RPC_URL_MAINNET || process.env.RPC_URL,
+      url: process.env.RPC_URL_MAINNET || process.env.RPC_URL || "",
       chainId: 1,
     },
     polygon: {
-      url: process.env.RPC_URL_POLYGON || process.env.RPC_URL,
+      url: process.env.RPC_URL_POLYGON || process.env.RPC_URL || "",
       chainId: 137,
     },
     auto: {
-      url: process.env.RPC_URL,
+      url: process.env.RPC_URL || "",
     },
   },
   contractSizer: {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -19,6 +19,23 @@ module.exports = {
       evmVersion: "cancun",
     },
   },
+  networks: {
+    sepolia: {
+      url: process.env.RPC_URL_SEPOLIA || process.env.RPC_URL,
+      chainId: 11155111,
+    },
+    mainnet: {
+      url: process.env.RPC_URL_MAINNET || process.env.RPC_URL,
+      chainId: 1,
+    },
+    polygon: {
+      url: process.env.RPC_URL_POLYGON || process.env.RPC_URL,
+      chainId: 137,
+    },
+    auto: {
+      url: process.env.RPC_URL,
+    },
+  },
   contractSizer: {
     alphaSort: true,
     runOnCompile: false,

--- a/hhtasks.js
+++ b/hhtasks.js
@@ -1,0 +1,18 @@
+const { task, types } = require("hardhat/config");
+const { getAccessControlInfo } = require("./js/getAccessControlInfo");
+
+function addTasks() {
+  task("amp:getAccessControlInfo", "Gets access control information for an AccessManagedProxy contract")
+    .addParam("contractAddress", "The contract address", undefined, types.address)
+    .addOptionalParam("chainId", "Chain ID (default: 1)", "1", types.string)
+    .setAction(async function (taskArgs) {
+      const result = await getAccessControlInfo(taskArgs.contractAddress, taskArgs.chainId);
+      
+      console.log(JSON.stringify(result, null, 2));
+    });
+}
+
+module.exports = {
+  addTasks,
+};
+

--- a/hhtasks.js
+++ b/hhtasks.js
@@ -1,18 +1,82 @@
+const fs = require("fs");
 const { task, types } = require("hardhat/config");
-const { getAccessControlInfo } = require("./js/getAccessControlInfo");
+const { readImplementationAddress } = require("@ensuro/utils/js/utils");
+const { getAccessControlInfo, getAbiFromEtherscan } = require("./js/getAccessControlInfo");
+
+function writeToCSVOutput(accessControlInfo) {
+  // Just methods in the output
+  let ret = "selector,method,type,isPassThru,roleId,roleName\n";
+
+  const countByMethod = accessControlInfo.rolesByMethod.reduce((methodCounter, item) => {
+    methodCounter[item.method] = (methodCounter[item.method] || 0) + 1;
+    return methodCounter;
+  }, {});
+
+  for (methodACI of accessControlInfo.rolesByMethod) {
+    const methodCol =
+      methodACI.method === null
+        ? "<unknown>"
+        : countByMethod[methodACI.method] == 1
+          ? methodACI.method
+          : methodACI.fullMethod.replace(/^function /, "");
+    const columns = [
+      methodACI.selector,
+      `"${methodCol}"`,
+      methodACI.type || "<unknown>",
+      methodACI.passThru ? "true" : "false",
+      `"${methodACI.roleId.toString()}"`,
+      `"${methodACI.roleName}"`,
+    ];
+    ret += columns.join(",") + "\n";
+  }
+  return ret;
+}
+
+function writeToJSONOutput(accessControlInfo) {
+  return JSON.stringify(accessControlInfo, (_, v) => (typeof v == "bigint" ? v.toString() : v), 2);
+}
 
 function addTasks() {
   task("amp:getAccessControlInfo", "Gets access control information for an AccessManagedProxy contract")
     .addParam("contractAddress", "The contract address", undefined, types.address)
-    .addOptionalParam("chainId", "Chain ID (default: 1)", "1", types.string)
+    .addOptionalParam(
+      "contractFactory",
+      "Contract Factory (to get the interface, otherwise, fetch from etherscan)",
+      undefined,
+      types.string
+    )
+    .addOptionalParam("chainId", "Chain ID (default: guess from network)", undefined, types.number)
+    .addOptionalParam("format", "Output format", "csv", types.string)
+    .addOptionalParam("output", "Output file", "-", types.string)
     .setAction(async function (taskArgs) {
-      const result = await getAccessControlInfo(taskArgs.contractAddress, taskArgs.chainId);
-      
-      console.log(JSON.stringify(result, null, 2));
+      let contractInterface;
+      if (taskArgs.contractFactory === undefined) {
+        // Get the ABI from Etherscan
+        const implementationAddr = await readImplementationAddress(hre, taskArgs.contractAddress);
+        let chainId = taskArgs.chainId;
+        if (chainId === undefined) {
+          chainId = parseInt(await hre.network.provider.send("eth_chainId"));
+        }
+        const ABI = await getAbiFromEtherscan(implementationAddr, chainId);
+        contractInterface = new ethers.Interface(ABI);
+      } else {
+        const factory = await ethers.getContractFactory(taskArgs.contractFactory);
+        contractInterface = factory.interface;
+      }
+      const result = await getAccessControlInfo(hre, taskArgs.contractAddress, contractInterface);
+      const formatFunction = {
+        csv: writeToCSVOutput,
+        json: writeToJSONOutput,
+      }[taskArgs.format];
+      const output = formatFunction(result);
+      if (taskArgs.output === "-") {
+        console.log(output);
+      } else {
+        fs.writeFileSync(taskArgs.output, output);
+      }
     });
 }
 
 module.exports = {
   addTasks,
 };
-

--- a/hhtasks.js
+++ b/hhtasks.js
@@ -57,7 +57,8 @@ function addTasks() {
         if (chainId === undefined) {
           chainId = parseInt(await hre.network.provider.send("eth_chainId"));
         }
-        const ABI = await getAbiFromEtherscan(implementationAddr, chainId);
+        const apiKey = process.env.ETHERSCAN_API_KEY || "";
+        const ABI = await getAbiFromEtherscan(implementationAddr, chainId, apiKey);
         contractInterface = new ethers.Interface(ABI);
       } else {
         const factory = await ethers.getContractFactory(taskArgs.contractFactory);

--- a/js/getAccessControlInfo.js
+++ b/js/getAccessControlInfo.js
@@ -1,0 +1,105 @@
+const { ethers } = require("ethers");
+
+/**
+ * Gets the ABI of a contract from Etherscan
+ * @param {string} contractAddress - The contract address
+ * @param {string} chainId - Chain ID (default: "1" )
+ * @returns {Promise<Array>} The contract ABI
+ */
+async function getAbiFromEtherscan(contractAddress, chainId = "1") {
+  const apiKey = process.env.ETHERSCAN_API_KEY || "";
+  const url = `https://api.etherscan.io/v2/api?module=contract&action=getabi&address=${contractAddress}&chainid=${chainId}&apikey=${apiKey}`;
+
+  const response = await fetch(url);
+  const data = await response.json();
+
+  if (data.status === "1" && data.result) {
+    return JSON.parse(data.result);
+  }
+
+  throw new Error(`Failed to get ABI from Etherscan: ${data.message}`);
+}
+
+function getContract(contractAddress, abi) {
+  const rpcUrl = process.env.RPC_URL;
+  if (!rpcUrl) {
+    throw new Error("RPC_URL environment variable is required");
+  }
+  
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  return new ethers.Contract(contractAddress, abi, provider);
+}
+
+/**
+ * Gets access control information for an AccessManagedProxy contract
+ * @param {string} contractAddress - The contract address
+ * @param {string} chainId - Chain ID (default: "1")
+ * @returns {Promise<Object>} Access control information
+ */
+async function getAccessControlInfo(contractAddress, chainId = "1") {
+  const abi = await getAbiFromEtherscan(contractAddress, chainId);
+  
+  const contract = getContract(contractAddress, abi);
+  
+  const accessManager = await contract.ACCESS_MANAGER();
+  
+  const passThruMethods = await contract.PASS_THRU_METHODS();
+  
+  const accessManagerAbi = await getAbiFromEtherscan(accessManager, chainId);
+  const accessManagerContract = getContract(accessManager, accessManagerAbi);
+  
+  const interface = new ethers.Interface(abi);
+  const functions = interface.fragments.filter((f) => f.type === "function");
+  
+  const rolesByMethod = [];
+  
+  for (const func of functions) {
+    const selector = func.selector;
+    const isPassThru = passThruMethods.includes(selector);
+    
+    let roleId = null;
+    let roleName = null;
+    
+    if (!isPassThru) {
+      try {
+        const eventFilter = accessManagerContract.filters.TargetFunctionRoleUpdated(contractAddress, selector);
+        const events = await accessManagerContract.queryFilter(eventFilter);
+        
+        if (events.length > 0) {
+          const latestEvent = events[events.length - 1];
+          roleId = latestEvent.args.roleId;
+          
+          const PUBLIC_ROLE = await accessManagerContract.PUBLIC_ROLE();
+          const ADMIN_ROLE = await accessManagerContract.ADMIN_ROLE();
+          
+          if (PUBLIC_ROLE && roleId === PUBLIC_ROLE) {
+            roleName = "PUBLIC_ROLE";
+          } else if (ADMIN_ROLE && roleId === ADMIN_ROLE) {
+            roleName = "ADMIN_ROLE";
+          } else {
+            roleName = `ROLE_${roleId.toString()}`;
+          }
+        }
+      } catch (error) {
+        console.warn(`Could not get role for selector ${selector}: ${error.message}`);
+      }
+    }
+    
+    rolesByMethod.push({
+      selector: selector,
+      method: func.name,
+      fullMethod: func.format("full"),
+      role_id: roleId ? roleId.toString() : null,
+      role_name: roleName,
+      pass_thru: isPassThru
+    });
+  }
+  
+  return {
+    ACCESS_MANAGER: accessManager,
+    PASS_THRU_METHODS: passThruMethods,
+    roles_by_method: rolesByMethod
+  };
+}
+
+module.exports = { getContract, getAbiFromEtherscan, getAccessControlInfo };

--- a/js/getAccessControlInfo.js
+++ b/js/getAccessControlInfo.js
@@ -1,5 +1,8 @@
 const { ethers } = require("ethers");
 
+const PUBLIC_ROLE = 2n ** 64n - 1n;
+const ADMIN_ROLE = 0n;
+
 /**
  * Gets the ABI of a contract from Etherscan
  * @param {string} contractAddress - The contract address
@@ -20,98 +23,98 @@ async function getAbiFromEtherscan(contractAddress, chainId = "1") {
   throw new Error(`Failed to get ABI from Etherscan: ${data.message}`);
 }
 
-function getProvider() {
-  const rpcUrl = process.env.RPC_URL;
-  if (!rpcUrl) {
-    throw new Error("RPC_URL environment variable is required");
-  }
-  return new ethers.JsonRpcProvider(rpcUrl);
-}
-
-function getContract(contractAddress, abi) {
-  const provider = getProvider();
-  return new ethers.Contract(contractAddress, abi, provider);
-}
-
-/**
- * Gets the implementation address from an ERC1967 proxy
- * @param {string} proxyAddress - The proxy contract address
- * @returns {Promise<string>} The implementation contract address
- */
-async function getImplementationAddress(proxyAddress) {
-  const provider = getProvider();
-  const IMPLEMENTATION_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
-  const implementationSlotValue = await provider.getStorage(proxyAddress, IMPLEMENTATION_SLOT);
-  return ethers.getAddress("0x" + implementationSlotValue.slice(-40));
-}
-
 /**
  * Gets access control information for an AccessManagedProxy contract
- * @param {string} contractAddress - The contract address
- * @param {string} chainId - Chain ID (default: "1")
+ * @param contractAddress - The contract address
+ * @param contractInterface - The interface of the implementation contract (to get function names)
+ * @param opts - Object with some optional parameters:
+ *                  acMgrContract: name of the AccessManager contract (default "AccessManager")
+ *                  ampContract: name of the AccessManagedProxy contract (default "AccessManagedProxy")
  * @returns {Promise<Object>} Access control information
  */
-async function getAccessControlInfo(contractAddress, chainId = "1") {
-  const proxyAbi = await getAbiFromEtherscan(contractAddress, chainId);
-  const proxyContract = getContract(contractAddress, proxyAbi);
-  
+async function getAccessControlInfo(hre, contractAddress, contractInterface, opts = {}) {
+  const proxyContract = await hre.ethers.getContractAt(opts.ampContract || "AccessManagedProxy", contractAddress);
+
   const accessManager = await proxyContract.ACCESS_MANAGER();
   const passThruMethods = await proxyContract.PASS_THRU_METHODS();
-  
-  const implementationAddress = await getImplementationAddress(contractAddress);
-  
-  const implementationAbi = await getAbiFromEtherscan(implementationAddress, chainId);
-  
-  const accessManagerAbi = await getAbiFromEtherscan(accessManager, chainId);
-  const accessManagerContract = getContract(accessManager, accessManagerAbi);
-  
-  const interface = new ethers.Interface(implementationAbi);
-  const functions = interface.fragments.filter((f) => f.type === "function");
-  
-  const PUBLIC_ROLE = await accessManagerContract.PUBLIC_ROLE();
-  const ADMIN_ROLE = await accessManagerContract.ADMIN_ROLE();
-  
+
+  const accessManagerContract = await hre.ethers.getContractAt(opts.acMgrContract || "AccessManager", accessManager);
+
+  const functions = contractInterface.fragments.filter((f) => f.type === "function");
+
+  const roleNames = {};
+  roleNames[PUBLIC_ROLE] = "PUBLIC_ROLE";
+  roleNames[ADMIN_ROLE] = "ADMIN_ROLE";
+
+  const labelEventFilter = accessManagerContract.filters.RoleLabel();
+  for (const lblEvt of await accessManagerContract.queryFilter(labelEventFilter)) {
+    roleNames[lblEvt.args.roleId] = lblEvt.args.label;
+  }
   const rolesByMethod = [];
-  
+
+  const setTargetFunctionFilter = accessManagerContract.filters.TargetFunctionRoleUpdated(contractAddress);
+  const rolesBySelector = Object.fromEntries(
+    (await accessManagerContract.queryFilter(setTargetFunctionFilter)).map((evt) => [
+      evt.args.selector,
+      evt.args.roleId,
+    ])
+  );
+
   for (const func of functions) {
     const selector = func.selector;
-    const isPassThru = passThruMethods.includes(selector);
-    
-    let roleId = null;
-    let roleName = null;
-    
-    if (!isPassThru) {
-      try {
-        roleId = await accessManagerContract.getTargetFunctionRole(contractAddress, selector);
-        
-        if (roleId === PUBLIC_ROLE) {
-          roleName = "PUBLIC_ROLE";
-        } else if (roleId === ADMIN_ROLE) {
-          roleName = "ADMIN_ROLE";
-        } else {
-          roleName = `ROLE_${roleId.toString()}`;
-        }
-      } catch (error) {
-        console.warn(`Could not get role for selector ${selector}: ${error.message}`);
-      }
-    }
-    
+
+    const roleId = rolesBySelector[selector] || ADMIN_ROLE;
+    const roleName = roleNames[roleId] || `ROLE_${roleId.toString}`;
+
     rolesByMethod.push({
       selector: selector,
       method: func.name,
-      fullMethod: func.format("full"),
+      fullMethod: func.format("minimal"),
       type: func.stateMutability,
-      role_id: roleId !== null && roleId !== undefined ? roleId.toString() : null,
-      role_name: roleName,
-      pass_thru: isPassThru
+      roleId: roleId,
+      roleName: roleName,
+      passThru: passThruMethods.includes(selector),
     });
   }
-  
+
+  const includedSelectors = new Set(rolesByMethod.map((x) => x.selector));
+
+  // Check all granted methods are included in the output, even if they are not in the ABI
+  for (const [selector, roleId] of Object.entries(rolesBySelector)) {
+    if (includedSelectors.has(selector)) continue;
+    const roleName = roleNames[roleId] || `ROLE_${roleId.toString}`;
+    rolesByMethod.push({
+      selector: selector,
+      method: null,
+      fullMethod: null,
+      type: null,
+      roleId: roleId,
+      roleName: roleName,
+      passThru: passThruMethods.includes(selector),
+    });
+    includedSelectors.add(selector);
+  }
+  // Complete with all the selectors that are in passThruMethods and not in the ABI nor in TargetFunctionRoleUpdated
+  // events
+  for (const selector of passThruMethods) {
+    if (includedSelectors.has(selector)) continue;
+    rolesByMethod.push({
+      selector: selector,
+      method: null,
+      fullMethod: null,
+      type: null,
+      roleId: ADMIN_ROLE,
+      roleName: roleNames[ADMIN_ROLE],
+      passThru: true,
+    });
+    includedSelectors.add(selector);
+  }
+
   return {
     ACCESS_MANAGER: accessManager,
     PASS_THRU_METHODS: passThruMethods,
-    roles_by_method: rolesByMethod
+    rolesByMethod: rolesByMethod,
   };
 }
 
-module.exports = { getContract, getAbiFromEtherscan, getAccessControlInfo, getImplementationAddress };
+module.exports = { getAbiFromEtherscan, getAccessControlInfo };

--- a/js/getAccessControlInfo.js
+++ b/js/getAccessControlInfo.js
@@ -7,10 +7,10 @@ const ADMIN_ROLE = 0n;
  * Gets the ABI of a contract from Etherscan
  * @param {string} contractAddress - The contract address
  * @param {string} chainId - Chain ID (default: "1" )
+ * @param {string} apiKey - Etherscan API Key (default: "" )
  * @returns {Promise<Array>} The contract ABI
  */
-async function getAbiFromEtherscan(contractAddress, chainId = "1") {
-  const apiKey = process.env.ETHERSCAN_API_KEY || "";
+async function getAbiFromEtherscan(contractAddress, chainId = "1", apiKey = "") {
   const url = `https://api.etherscan.io/v2/api?module=contract&action=getabi&address=${contractAddress}&chainid=${chainId}&apikey=${apiKey}`;
 
   const response = await fetch(url);


### PR DESCRIPTION
RPC_URL="https://example.rpc/foo" ETHERSCAN_API_KEY="foobar" npx hardhat amp:getAccessControlInfo --contract-address 0x123abc --chain-id 11155111

Returns:
```bash
{
    "ACCESS_MANAGER": ...,
    "PASS_THRU_METHODS": ,,,,
    "roles_by_method": [{selector: ..., method: "transfer", fullMethod: "transfer(uint256, xxx, xxx)", role_id: xxx, role_name: xxx, pass_thru: true/false}]
}
```